### PR TITLE
Update Forsyth County GA domain

### DIFF
--- a/WME-GIS-Layers.js
+++ b/WME-GIS-Layers.js
@@ -357,7 +357,7 @@
 // @connect gismaps.wichita.gov
 // @connect gismapserver.leegov.com
 // @connect gisp.co.genesee.ny.us
-// @connect gisp2.forsythco.com
+// @connect geo.forsythco.com
 // @connect gisprod10.co.fresno.ca.us
 // @connect gisprodops.chesco.org
 // @connect gisprpxy.itd.state.ma.us


### PR DESCRIPTION
Update Forsyth County GA domain per a change in their URL.

ramblinwreck_81 and ggrane helped to update the spreadsheet, but now the URL whitelist should also be updated.